### PR TITLE
support pandoc3 - return empty list instead of Null

### DIFF
--- a/pandoc_comments.py
+++ b/pandoc_comments.py
@@ -33,7 +33,7 @@ def action(k, v, fmt, meta):
 
         # Comments begin with a %
         if v[0]['t'] == 'Str' and v[0]['c'] and v[0]['c'][0] == '%':
-            return Null()
+            return []
 
     return None
 


### PR DESCRIPTION
On pandoc 3.1, the filter fails with the following error:

```
Error running filter /common/filters/pandoc-comments.py:
Error in $.blocks[254]: When parsing Text.Pandoc.Definition.Block expected an Object with a tag field where the value is one of [Plain, Para, LineBlock, CodeBlock, RawBlock, BlockQuote, OrderedList, BulletList, DefinitionList, Header, HorizontalRule, Table, Figure, Div], but got Null.
```

To fix it, I return `[]` instead of `Null()`, which is also according to the examples from `pandocfilters` repo.